### PR TITLE
Fix typo on main page

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,7 +1,7 @@
 ---
 home: true
 heroImage: /images/handlebars_logo.png
-tagline: Minimal templating on steriods
+tagline: Minimal templating on steroids
 actionText: Get Started →
 actionLink: /guide/
 features:


### PR DESCRIPTION
Fix misspelling of the word `steroids` in the main `index.md` file.