### PR TITLE
Add warning about no javascript escaping

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -162,6 +162,13 @@ parameters.
 This will escape the passed in parameters, but mark the response as safe, so Handlebars will not try to escape it even
 if the "triple-stash" is not used.
 
+::: warning
+
+Handlebars does not escape JavaScript strings. Using Handlebars in JavaScript such as in inline event handlers could
+potentially lead to cross-site scripting vulnerabilities.
+
+:::
+
 ## Partials
 
 Handlebars partials allow for code reuse by creating shared templates. You can register a partial using the

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -164,7 +164,7 @@ if the "triple-stash" is not used.
 
 ::: warning
 
-Handlebars does not escape JavaScript strings. Using Handlebars in JavaScript such as in inline event handlers could
+Handlebars does not escape JavaScript strings. Using Handlebars in JavaScript, such as in inline event handlers, could
 potentially lead to cross-site scripting vulnerabilities.
 
 :::


### PR DESCRIPTION
As discussed [in this issue](https://github.com/wycats/handlebars.js/issues/1653), putting handlebars in script tags or inline event handlers opens up a website to cross-site scripting vulnerabilities. This PR adds a warning message in the HTML Escaping section notifying potential users that JavaScript is not escaped.