### PR TITLE
Add Sub-Expression Notes to Guide

### DIFF
--- a/src/examples/builtin-helper-if-subexpression.md
+++ b/src/examples/builtin-helper-if-subexpression.md
@@ -1,0 +1,13 @@
+---
+layout: InteractivePlaygroundLayout
+example:
+  template: |
+    {{#if (isdefined value1)}}true{{else}}false{{/if}}
+    {{#if (isdefined value2)}}true{{else}}false{{/if}}
+  preparationScript: |
+    Handlebars.registerHelper('isdefined', function (value) {
+      return value !== undefined;
+    });
+  input:
+    value1: {}
+---

--- a/src/guide/block-helpers.md
+++ b/src/guide/block-helpers.md
@@ -372,25 +372,6 @@ which is an integer count. This value represents the number of block parameters 
 template. Parameters beyond this count will never be referenced and can safely be omitted by the helper if desired. This
 is optional and any additional parameters passed to the template will be silently ignored.
 
-## Sub-Expressions
-
-Helpers are the proposed way to add custom logic to templates.  You can write any helper and use it in a sub-expression.
-
-For example, in checking for initialization of a variable the [built-in `#if`](builtin-helpers.html#if) check might not 
-be appropriate as it returns false for empty collections.  You could write a helper that checks for "undefined" such as:
-
-```js
-Handlebars.registerHelper('isdefined', function (value) {
-  return value !== undefined;
-});
-```
-
-Then use your helper as a sub-expression:
-
-```handlebars
-{{#if (isdefined value)}}true{{else}}false{{/if}}
-```
-
 ## Raw Blocks
 
 Raw blocks are available for templates needing to handle unprocessed mustache blocks.

--- a/src/guide/block-helpers.md
+++ b/src/guide/block-helpers.md
@@ -372,6 +372,25 @@ which is an integer count. This value represents the number of block parameters 
 template. Parameters beyond this count will never be referenced and can safely be omitted by the helper if desired. This
 is optional and any additional parameters passed to the template will be silently ignored.
 
+## Sub-Expressions
+
+Helpers are the proposed way to add custom logic to templates.  You can write any helper and use it in a sub-expression.
+
+For example, in checking for initialization of a variable the [built-in `#if`](builtin-helpers.html#if) check might not 
+be appropriate as it returns false for empty collections.  You could write a helper that checks for "undefined" such as:
+
+```js
+Handlebars.registerHelper('isdefined', function (value) {
+  return value !== undefined;
+});
+```
+
+Then use your helper as a sub-expression:
+
+```handlebars
+{{#if (isdefined value)}}true{{else}}false{{/if}}
+```
+
 ## Raw Blocks
 
 Raw blocks are available for templates needing to handle unprocessed mustache blocks.

--- a/src/guide/builtin-helpers.md
+++ b/src/guide/builtin-helpers.md
@@ -27,6 +27,21 @@ section, marked by `else` is called an "else section".
 
 <ExamplePart examplePage="/examples/builtin-helper-ifelse-block.md" show="template" />
 
+### Sub-Expressions
+
+Helpers are the proposed way to add custom logic to templates. You can write any helper and use it in a sub-expression.
+
+For example, in checking for initialization of a variable the built-in `#if` check might not be appropriate as it
+returns false for empty collections (see [Utils.isEmpty](/api-reference/utilities.html#handlebars-utils-isempty-value)).
+
+You could write a helper that checks for "undefined" such as:
+
+<ExamplePart examplePage="/examples/builtin-helper-if-subexpression.md" show="preparationScript" />
+
+Then use your helper as a sub-expression:
+
+<ExamplePart examplePage="/examples/builtin-helper-if-subexpression.md" show="template" />
+
 ## #unless
 
 You can use the `unless` helper as the inverse of the `if` helper. Its block will be rendered if the expression returns


### PR DESCRIPTION

Addresses https://github.com/wycats/handlebars.js/issues/1531

Code Sample [Playground Link](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22nullValue%3A%20%7B%7B%23if%20(isdefined%20nullValue)%7D%7Dtrue%7B%7Belse%7D%7Dfalse%7B%7B%2Fif%7D%7D%5CnnonexistingProperty%3A%20%7B%7B%23if%20(isdefined%20nonexistingProperty)%7D%7Dtrue%7B%7Belse%7D%7Dfalse%7B%7B%2Fif%7D%7D%5Cnzero%3A%20%7B%7B%23if%20(isdefined%20zero)%7D%7Dtrue%7B%7Belse%7D%7Dfalse%7B%7B%2Fif%7D%7D%5CnemptyString%3A%20%7B%7B%23if%20(isdefined%20emptyString)%7D%7Dtrue%7B%7Belse%7D%7Dfalse%7B%7B%2Fif%7D%7D%5CnemptyArray%3A%20%7B%7B%23if%20(isdefined%20emptyArray)%7D%7Dtrue%7B%7Belse%7D%7Dfalse%7B%7B%2Fif%7D%7D%5Cn%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20nullValue%3A%20null%2C%5Cn%20%20zero%3A%200%2C%5Cn%20%20emptyString%3A%20''%2C%5Cn%20%20emptyArray%3A%20%5B%5D%5Cn%7D%5Cn%22%2C%22output%22%3A%22nullValue%3A%20true%5CnnonexistingProperty%3A%20false%5Cnzero%3A%20true%5CnemptyString%3A%20true%5CnemptyArray%3A%20true%5Cn%22%2C%22preparationScript%22%3A%22Handlebars.registerHelper('isdefined'%2C%20function%20(value)%20%7B%5Cn%20%20return%20value%20!%3D%3D%20undefined%3B%5Cn%7D)%3B%22%2C%22handlebarsVersion%22%3A%224.2.0%22%7D)

Ran `npm run preview` locally.
