### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/src/.vuepress/config-using-babel.js
+++ b/src/.vuepress/config-using-babel.js
@@ -26,6 +26,10 @@ export default {
   ],
   dest: "target/",
   themeConfig: {
+    algolia: {
+      apiKey: 'ceae3bc4e38c4b10f99cc802d1e6db96',
+      indexName: 'handlebarsjs'
+    },
     locales: {
       "/": {
         selectText: "Languages",


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.