### PR TITLE
docs: builtin-helpers #if includeZero documentation

### DIFF
--- a/src/examples/builtin-helper-if-block.md
+++ b/src/examples/builtin-helper-if-block.md
@@ -6,9 +6,16 @@ example:
     {{#if author}}
     <h1>{{firstName}} {{lastName}}</h1>
     {{/if}}
+    {{#if zeroValue}}
+    <h1>Does not render</h1>
+    {{/if}}
+    {{#if zeroValue includeZero=true}}
+    <h1>Does render</h1>
+    {{/if}}
     </div>
   input:
     author: true
     firstName: Yehuda
     lastName: Katz
+    zeroValue: 0
 ---

--- a/src/guide/builtin-helpers.md
+++ b/src/guide/builtin-helpers.md
@@ -3,7 +3,8 @@
 ## #if
 
 You can use the `if` helper to conditionally render a block. If its argument returns `false`, `undefined`, `null`, `""`,
-`0`, or `[]`, Handlebars will not render the block.
+`0`, or `[]`, Handlebars will not render the block. 
+Note: You can add the `includeZero=true` argument to make `0` render the block.
 
 <ExamplePart examplePage="/examples/builtin-helper-if-block.md" show="template" />
 

--- a/src/guide/builtin-helpers.md
+++ b/src/guide/builtin-helpers.md
@@ -3,8 +3,7 @@
 ## #if
 
 You can use the `if` helper to conditionally render a block. If its argument returns `false`, `undefined`, `null`, `""`,
-`0`, or `[]`, Handlebars will not render the block. 
-Note: You can add the `includeZero=true` argument to make `0` render the block.
+`0`, or `[]`, Handlebars will not render the block. Note: You can add the `includeZero=true` argument to make `0` render the block.
 
 <ExamplePart examplePage="/examples/builtin-helper-if-block.md" show="template" />
 


### PR DESCRIPTION
Adds documentation about using `includeZero=true` argument in the `#if` helper to make `0` return truthy.
Solves: https://github.com/handlebars-lang/docs/issues/63