### PR TITLE
fix: display mustache inline code block in block helpers section

### DIFF
--- a/src/guide/block-helpers.md
+++ b/src/guide/block-helpers.md
@@ -88,8 +88,12 @@ want to avoid repeating the parent name. The above template could be useful with
 
 ```
 
+::: v-pre
+
 Implementing a helper like this is a lot like implementing the `noop` helper. Helpers can take parameters, and
 parameters are evaluated just like expressions used directly inside `{{mustache}}` blocks.
+
+:::
 
 ```js
 Handlebars.registerHelper("with", function(context, options) {

--- a/src/zh/guide/block-helpers.md
+++ b/src/zh/guide/block-helpers.md
@@ -82,8 +82,12 @@ Handlebars.registerHelper("bold", function(options) {
 
 ```
 
+::: v-pre
+
 实现这样的助手代码并不像实现 `noop` 一样。助手代码可以获取参数，并且参数的计算就像直接在 `{{mustache}}` 代码块中直接使用
 的表达式一样。
+
+:::
 
 ```js
 Handlebars.registerHelper("with", function(context, options) {


### PR DESCRIPTION
**Fixes**: block helpers section missing `{{mustache}}` inline code block.

Current:
![handlebars_docs_mustache_inline_block_before](https://user-images.githubusercontent.com/9861724/111543806-dc2f2c80-8773-11eb-893d-2e65f250ad2f.png)

Expected:
![handlebars_docs_mustache_inline_block_after](https://user-images.githubusercontent.com/9861724/111543818-e05b4a00-8773-11eb-9677-c07369818a08.png)
