### PR TITLE
fix: display edit link text in contributing section

### DIFF
--- a/src/contributing/index.md
+++ b/src/contributing/index.md
@@ -15,7 +15,7 @@ This site is hosted on [Github](https://github.com/handlebars-lang/docs) and ren
 - Please create a [pull requests](https://help.github.com/en/articles/about-pull-requests) for any change that you would
   like to see on the page.
 - If your change only affects the contents of a single page, you can simply click the link
-  `{{$themeConfig.editLinkText}}` at the bottom of this page (see
+  `{{$themeLocaleConfig.editLinkText}}` at the bottom of this page (see
   [Editing files in another user's repository](https://help.github.com/en/articles/editing-files-in-another-users-repository))
   for details.
 - For more complex changes (styling, multiple pages, new pages, fixing build problems), you should

--- a/src/zh/contributing/index.md
+++ b/src/zh/contributing/index.md
@@ -11,7 +11,7 @@ Handlebars 是一个开源项目。没有 _“文档部门”_ 使文档保持�
 该站点托管在 [Github](https://github.com/handlebars-lang/docs) 上，并使用 [VuePress](https://v1.vuepress.vuejs.org/)。
 
 - 请为你要进行的影响此文档的任何更改创建一个 [pull requests](https://help.github.com/en/articles/about-pull-requests)。
-- 如果更改仅影响单页内容，则只需单击该页面底部的 {{$themeConfig.editLinkText}}} 按钮。（请参阅
+- 如果更改仅影响单页内容，则只需单击该页面底部的 `{{$themeLocaleConfig.editLinkText}}` 按钮。（请参阅
    [编辑另一个用户存储库中的文件](https://help.github.com/en/articles/editing-files-in-another-users-repository)。）
 - 对于更复杂的更改（样式，多个页面，新页面，修复构建问题），你应该
    [fork repo](https://help.github.com/en/articles/fork-a-repo) 并在完成之后提交 Pull Request。 [Contributing


### PR DESCRIPTION
**Fixes**: contributing section missing edit link text.

Current:
![handlebars_docs_edit_link_text_before](https://user-images.githubusercontent.com/9861724/111544579-f7e70280-8774-11eb-96f7-dc6817c4e092.png)

Expected:
![handlebars_docs_edit_link_text_after](https://user-images.githubusercontent.com/9861724/111544638-0f25f000-8775-11eb-8e79-49af9d52218a.png)
