### PR TITLE
chore: fix scripts glob syntax on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "preview": "npm run clean && npm run test-and-build && cd target && static-server",
     "fix": "npm run format && npm run lintfix",
     "test-and-build": "concurrently --kill-others-on-fail npm:lint npm:test npm:build",
-    "lint": "eslint '**/*.{js,vue}' ",
-    "lintfix": "eslint --fix '**/*.{js,vue}' ",
+    "lint": "eslint \"**/*.{js,vue}\"",
+    "lintfix": "eslint --fix \"**/*.{js,vue}\"",
     "test": "jest",
-    "format": "prettier --write 'src/**/*.{js,css,json,md,vue}'",
+    "format": "prettier --write \"src/**/*.{js,css,json,md,vue}\"",
     "build": "vuepress build src"
   },
   "repository": {


### PR DESCRIPTION
**Fixes**: running scripts using glob syntax on Windows