### PR TITLE
feat: add information about the Vite plugin

### DIFF
--- a/src/installation/integrations.md
+++ b/src/installation/integrations.md
@@ -64,3 +64,17 @@ https://www.npmjs.com/package/@inventory/parcel-plugin-handlebars
 TODO: Write text here
 
 https://www.npmjs.com/package/parcel-plugin-handlebars-precompile
+
+## Vite: vite-plugin-handlebars
+
+The [vite-plugin-handlebars](https://github.com/alexlafroscia/vite-plugin-handlebars) package for Vite 2 allows for
+running your HTML files through the Handlebars compiler. Once installed, it can be added to Vite like so:
+
+```js
+// vite.config.js
+import handlebars from "vite-plugin-handlebars";
+
+export default {
+  plugins: [handlebars()],
+};
+```


### PR DESCRIPTION
I have been working on a Handlebars plugin for Vite 2 that lets you use Handlebars in any HTML file that you might have in your site. I figured it would be nice to mention it as an integration on the Handlebars docs site!

I tried to run the `preview` script but it didn't work on my branch -- it seems to be failing on `master` as well.

I _did_ run the `dev` command locally, though, and the addition looks good!