### PR TITLE
Link playground on homepage

### DIFF
--- a/src/.vuepress/config-using-babel.js
+++ b/src/.vuepress/config-using-babel.js
@@ -128,6 +128,15 @@ export default {
         updatePopup: true,
       },
     ],
+    [
+      "vuepress-plugin-container",
+      {
+        type: "playground",
+        defaultTitle: "",
+        before: (content) => `<div class="playground">${content}`,
+        after: "</div>",
+      },
+    ],
     storeHandlebarsVersionAtVuePrototype,
     interactiveExamples,
     buttonLink,

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -64,14 +64,26 @@ $contentBorderRadius = 0.5rem
     .theme-default-content {
 
         background-color: transparent !important;
+        text-align: center;
 
-        @media (min-width: $MQMobile + 1px) {
-            position: absolute;
-            left: 0;
-            top: $navbarHeight;
-            margin: 1rem;
+        .devswag {
+            @media (min-width: $MQMobile + 1px) {
+                position: absolute;
+                left: 0;
+                top: $navbarHeight;
+                margin: 1rem;
+            }
         }
 
+        .playground a {
+            display: inline-block;
+            width: 100%;
+            max-width: 400px;
+            background-color: $featuresBgColor;
+            border: 1px solid $borderColor;
+            border-radius: 4px;
+            padding: .8rem 0;
+        }
     }
 
     .footer {

--- a/src/.vuepress/styles/palette.styl
+++ b/src/.vuepress/styles/palette.styl
@@ -12,7 +12,7 @@ $navbarBgColor = #fda
 $sidebarBgColor = $navbarBgColor
 
 $bodyBgColor = $baseColor
-$featuresBgColor = #ddd
+$featuresBgColor = #eee
 $contentBgColor = #efefef
 
 $exampleWorkspaceDefaultMargin = 0.5rem;

--- a/src/index.md
+++ b/src/index.md
@@ -22,3 +22,7 @@ footer: MIT licensed | Copyright (C) 2011-2019 by Yehuda Katz
 <a class="devswag" href="https://www.devswag.com/collections/handlebars">
     <img src="images/handlebars-devswag.png">
 </a>
+
+::: playground
+[Live Demo →](playground.md)
+:::

--- a/src/zh/index.md
+++ b/src/zh/index.md
@@ -20,3 +20,5 @@ footer: MIT 许可 | Copyright (C) 2011-2019 by Yehuda Katz
 <a class="devswag" href="https://www.devswag.com/collections/handlebars">
     <img src="/images/handlebars-devswag.png">
 </a>
+
+::: playground [在线演示 →](playground.md) :::

--- a/src/zh/index.md
+++ b/src/zh/index.md
@@ -21,4 +21,6 @@ footer: MIT 许可 | Copyright (C) 2011-2019 by Yehuda Katz
     <img src="/images/handlebars-devswag.png">
 </a>
 
-::: playground [在线演示 →](playground.md) :::
+::: playground
+[在线演示 →](playground.md)
+:::


### PR DESCRIPTION
See commits for details.

An alternative would be to link the playground in the nav-bar, like on typescriptlang.org.