### PR TITLE
move 'Other sources' links into 'Improve the docs'

### DIFF
--- a/src/.vuepress/config-using-babel.js
+++ b/src/.vuepress/config-using-babel.js
@@ -38,17 +38,6 @@ export default {
           { text: "Installation", link: "/installation/" },
           { text: "API reference", link: "/api-reference/" },
           { text: "Improve the docs", link: "/contributing/" },
-          {
-            text: "Other sources",
-            items: [
-              { text: "The old handlebars-website", link: "https://handlebars-archive.knappi.org/" },
-              { text: "Release notes", link: "https://github.com/wycats/handlebars.js/blob/master/release-notes.md" },
-              {
-                text: "Issues with label 'docs-needed'",
-                link: "https://github.com/wycats/handlebars.js/issues?q=is%3Aopen+is%3Aissue+label%3Adocs-needed",
-              },
-            ],
-          },
         ],
         sidebar: {
           "/installation/": ["", "precompilation.md", "integrations.md", "when-to-use-handlebars.md"],
@@ -81,17 +70,6 @@ export default {
           { text: "安装", link: "/zh/installation/" },
           { text: "API 参考", link: "/zh/api-reference/" },
           { text: "改进文档", link: "/zh/contributing/" },
-          {
-            text: "其他资源",
-            items: [
-              { text: "Handlebars 网站（旧）", link: "https://handlebars-archive.knappi.org/" },
-              { text: "发行说明", link: "https://github.com/wycats/handlebars.js/blob/master/release-notes.md" },
-              {
-                text: "带有 'docs-needed' 标签的 Issues",
-                link: "https://github.com/wycats/handlebars.js/issues?q=is%3Aopen+is%3Aissue+label%3Adocs-needed",
-              },
-            ],
-          },
         ],
         sidebar: {
           "/zh/installation/": ["", "precompilation.md", "integrations.md", "when-to-use-handlebars.md"],

--- a/src/contributing/index.md
+++ b/src/contributing/index.md
@@ -5,6 +5,10 @@
 Handlebars is an open-source project. There is no _"documentation department"_ that keeps the docs up-to-date. This
 documentation site requires your help to be a good and helpful site.
 
+[Release notes](https://github.com/wycats/handlebars.js/blob/master/release-notes.md)<br>
+[Issues with label 'docs-needed'](https://github.com/wycats/handlebars.js/issues?q=is%3Aopen+is%3Aissue+label%3Adocs-needed)<br>
+[The old Handlebars website](https://handlebars-archive.knappi.org)
+
 The following sections should help you help us improve the documentation.
 
 ## How do I submit contributions?

--- a/src/zh/contributing/index.md
+++ b/src/zh/contributing/index.md
@@ -2,7 +2,11 @@
 
 [[toc]]
 
-Handlebars 是一个开源项目。没有 _“文档部门”_ 使文档保持最新。 Handlebars 文档站需要你的帮助才能变得更加优秀。
+Handlebars 是一个开源项目。没有 _“文档部门”_ 使文档保持最新。 Handlebars 文档站需要你的帮助才能变得更加优秀.
+
+[发行说明](https://github.com/wycats/handlebars.js/blob/master/release-notes.md)<br>
+[带有 'docs-needed' 标签的 Issues](https://github.com/wycats/handlebars.js/issues?q=is%3Aopen+is%3Aissue+label%3Adocs-needed)<br>
+[Handlebars 网站（旧](https://handlebars-archive.knappi.org)
 
 以下各节将帮助你帮助我们改进文档。
 


### PR DESCRIPTION
Hello! I thought the navigation bar was a bit too long, so I'm proposing moving these links into the 'Improve the docs' section. I did this for both languages.

Side note: I think the Languages and Github links need to be moved as well, but I may open another PR for that. I'm open to ideas about how to incorporate them in a more 'responsive' way. I don't want to make too many changes without some feedback first. Thanks for taking a look.