### PR TITLE
move github link to bottom

### DIFF
--- a/src/.vuepress/config-using-babel.js
+++ b/src/.vuepress/config-using-babel.js
@@ -94,9 +94,6 @@ export default {
         docsDir: "src/zh",
       },
     },
-    repo: "wycats/handlebars.js",
-    docsRepo: "handlebars-lang/docs",
-    docsDir: "src",
   },
   plugins: [
     [

--- a/src/index.md
+++ b/src/index.md
@@ -23,6 +23,4 @@ footer: MIT licensed | Copyright (C) 2011-2019 by Yehuda Katz
     <img src="images/handlebars-devswag.png">
 </a>
 
-::: playground
-[Live Demo →](playground.md)
-:::
+::: playground [Live Demo →](playground.md)<br><br> [GitHub →](https://github.com/handlebars-lang/handlebars.js) :::

--- a/src/index.md
+++ b/src/index.md
@@ -23,4 +23,7 @@ footer: MIT licensed | Copyright (C) 2011-2019 by Yehuda Katz
     <img src="images/handlebars-devswag.png">
 </a>
 
-::: playground [Live Demo →](playground.md)<br><br> [GitHub →](https://github.com/handlebars-lang/handlebars.js) :::
+::: playground 
+[Live Demo →](playground.md)<br><br>
+[GitHub →](https://github.com/handlebars-lang/handlebars.js)
+:::


### PR DESCRIPTION
Hey, I thought it would make sense to move the GitHub link to the bottom to save space in the top nav bar. This is a continuation of PR #105.