### PR TITLE
remove  wrong statement about literal statements

### DIFF
--- a/src/guide/expressions.md
+++ b/src/guide/expressions.md
@@ -88,8 +88,6 @@ In addition, the words `true`, `false`, `null` and `undefined` are only allowed 
 To reference a property that is not a valid identifier, you can use segment-literal notation, `[`. You may not include a
 closing `]` in a path-literal, but all other characters are allowed.
 
-JavaScript-style strings, `"` and `'`, may also be used instead of `[` pairs.
-
 <ExamplePart examplePage="/examples/literal-segments.md" show="template" />
 
 ## HTML-escaping

--- a/src/zh/guide/expressions.md
+++ b/src/zh/guide/expressions.md
@@ -86,8 +86,6 @@ _Whitespace_ `!` `"` `#` `%` `&` `'` `(` `)` `*` `+` `,` `.` `/` `;` `<` `=` `>`
 
 若想引用一个并非合法的标识符，你可以使用 `[`。在路径表达式中你不必使用 `]` 来关闭它，但其他表达式中是需要的。
 
-JavaScript 样式的字符串如 `"` 和 `'` 也可用于替代 `[`。
-
 <ExamplePart examplePage="/zh/examples/literal-segments.md" show="template" />
 
 ## HTML 转义


### PR DESCRIPTION
`"` and `'` are not allowed as literal segment. At best, they may be used as `LiteralExpression` as parameter for helpers, but a template like 

```
{{'my id containing spaces'}} 
``` 

just does not parse