### PR TITLE
Update escape character usage

### DIFF
--- a/src/guide/expressions.md
+++ b/src/guide/expressions.md
@@ -302,12 +302,12 @@ will render
 ::: v-pre
 
 Handlebars content may be escaped in one of two ways, inline escapes or raw block helpers. Inline escapes created by
-prefixing a mustache block with `\`. Raw blocks are created using `{{{{` mustache braces.
+prefixing a mustache block with `\\`. Raw blocks are created using `{{{{` mustache braces.
 
 :::
 
 ```handlebars
-\{{escaped}}
+\\{{escaped}}
 {{{{raw}}}}
   {{escaped}}
 {{{{/raw}}}}

--- a/src/zh/guide/expressions.md
+++ b/src/zh/guide/expressions.md
@@ -287,13 +287,13 @@ Handlebars 对子级表达式提供了支持，这使你可以在单个 Mustache
 
 ::: v-pre
 
-Handlebars 可以从这两种方式中的任何一种转义：「内联转义」或「RAW 块助手代码」。内联转义通过 Mustache 代码块前置 `\` 实现
+Handlebars 可以从这两种方式中的任何一种转义：「内联转义」或「RAW 块助手代码」。内联转义通过 Mustache 代码块前置 `\\` 实现
 ，而 RAW 代码块通过使用 `{{{{` 实现。
 
 :::
 
 ```handlebars
-\{{escaped}}
+\\{{escaped}}
 {{{{raw}}}}
   {{escaped}}
 {{{{/raw}}}}


### PR DESCRIPTION
Hi, I found that using single back slashes don't work anymore for version `4.7.7`. Double slashes work to escape the characters.

Sample code I used to prove this:
```
const expectedString = `{{escaped}}`
console.log('single slash escape:', handlebars.compile(`\{{escaped}}`)() == expectedString)
console.log('double slash escape:', handlebars.compile(`\\{{escaped}}`)() == expectedString)
```

![image](https://github.com/handlebars-lang/docs/assets/56548631/829d963a-b870-4bd8-868f-71d202abb0fb)
![image](https://github.com/handlebars-lang/docs/assets/56548631/acf32bda-00ae-488a-90ba-08db824265b1)

