### PR TITLE
docs: add html-bundler-webpack-plugin to Integrations

### DIFF
--- a/src/installation/integrations.md
+++ b/src/installation/integrations.md
@@ -26,6 +26,12 @@ import compiledTemplate from "./template.handlebars";
 The [handlebars-webpack-plugin](https://github.com/sagold/handlebars-webpack-plugin) uses Handlebars to build your
 HTML-pages statically when compiling your application
 
+## Webpack: html-bundler-webpack-plugin
+
+The [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) uses various templating
+engines, [including Handlebars](https://github.com/webdiscus/html-bundler-webpack-plugin#using-the-handlebars), to
+render templates and bundle styles and scripts into generated HTML.
+
 ## Babel: handlebars-inline-precompile
 
 The
@@ -50,14 +56,12 @@ const compiledTemplate = require("./template.handlebars");
 
 ## Parcel: parcel-plugin-handlebars
 
-There is an old plugin for parcel:
-https://www.npmjs.com/package/parcel-plugin-handlebars
+There is an old plugin for parcel: https://www.npmjs.com/package/parcel-plugin-handlebars
 
 But you should use one of the many forks of this package, which are more up-to-date:
 https://www.npmjs.com/search?q=parcel-plugin-handlebars
 
-The most recent one is:
-https://www.npmjs.com/package/@inventory/parcel-plugin-handlebars
+The most recent one is: https://www.npmjs.com/package/@inventory/parcel-plugin-handlebars
 
 ## Parcel: parcel-plugin-handlebars-precompile
 

--- a/src/zh/installation/integrations.md
+++ b/src/zh/installation/integrations.md
@@ -23,6 +23,12 @@ import compiledTemplate from "./template.handlebars";
 
 [handlebars-webpack-plugin](https://github.com/sagold/handlebars-webpack-plugin) 使用 Handlebars 构建你的静态 HTML 页面
 
+## Webpack: html-bundler-webpack-plugin
+
+[html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) 支持使用包括
+[Handlebars](https://github.com/webdiscus/html-bundler-webpack-plugin#using-the-handlebars)
+在内的几种模板引擎来渲染模板，并将样式和脚本打包到生成的 HTML 文件中。
+
 ## Babel: handlebars-inline-precompile
 
 [babel-plugin-handlebars-inline-precompile](https://github.com/jamiebuilds/babel-plugin-handlebars-inline-precompile) 提


### PR DESCRIPTION
Hello,

I have added the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) on the  integrations page.

This plugin uses various templating engines, including Handlebars. 
The plugin allows to define Handlebars template files as entry points and use references to script and style source files directly in the template.

Thanks!