### PR TITLE
Fix rendering of CLI help-message

### DIFF
--- a/src/.vuepress/plugins/update-handlebars-cli-help.js
+++ b/src/.vuepress/plugins/update-handlebars-cli-help.js
@@ -8,7 +8,7 @@ export function updateHandlebarsCliHelp() {
   return {
     name: "update the 'handlebars --help' output.",
     extendMarkdown(md) {
-      md.block.ruler.before("fence", "handlebars_help_output", function(state, startLine, endLine, silent) {
+      md.block.ruler.before("fence", "handlebars_help_output", function (state, startLine, endLine, silent) {
         const pos = state.bMarks[startLine] + state.tShift[startLine];
         const max = state.eMarks[startLine];
         if (state.src.slice(pos, max) !== "!HANDLEBARS_HELP!") {
@@ -29,17 +29,17 @@ export function updateHandlebarsCliHelp() {
         token.map = [startLine, startLine + 1];
         return true;
       });
-    }
+    },
   };
 }
 
 function getHandlebarsHelpFromCli() {
   const handlebarsCli = require.resolve("handlebars/bin/handlebars");
   const nodeExecutable = process.argv[0];
-  const { stderr } = cp.spawnSync(nodeExecutable, [handlebarsCli, "--help"], {
+  const { stdout } = cp.spawnSync(nodeExecutable, [handlebarsCli, "--help"], {
     argv0: "handlebars",
     stdio: ["pipe", "pipe", "pipe"],
-    encoding: "utf-8"
+    encoding: "utf-8",
   });
-  return stderr.replace(/^Usage: \S+ \S+/m, "handlebars");
+  return stdout;
 }

--- a/src/installation/precompilation.md
+++ b/src/installation/precompilation.md
@@ -49,7 +49,7 @@ time, the `--knownOnly` option provides the smallest generated code that also pr
 If using the precompiler's normal mode, the resulting templates will be stored to the Handlebars.templates object using
 the relative template name sans the extension. These templates may be executed in the same manner as templates. If using
 the simple mode the precompiler will generate a single javascript method. To execute this method it must be passed to
-the Handlebars.template method and the resulting object may be used as normal.
+the `Handlebars.template()` method and the resulting object may be used as normal.
 
 ## Precompiling Templates Inside NodeJS
 
@@ -75,7 +75,7 @@ Finally, you can reference these templates dynamically in your Javascript.
 
 ```js
 var result = Handlebars.partials["test1"]({ name: "yourname" });
-//do whatever you want with the result
+// do whatever you want with the result
 ```
 
 ## Integrations

--- a/src/zh/installation/precompilation.md
+++ b/src/zh/installation/precompilation.md
@@ -46,7 +46,7 @@ Handlebars 编译器将优化对这些 helper 的访问以提高性能。当所�
 
 如果使用预编译器的 normal 模式，则预编译结果将存储到 Handlebars.templates 对象下对应的模板名称（不带扩展名）的对象中。这
 些预编译模板可以以和普通模板相同的方式执行。如果使用 simple 模式，预编译器将生成一个 JavaScript 方法。要执行此方法，必须
-将其传递给 Handlebars.template 方法，生成的对象也可以以相同的方式使用。
+将其传递给 `Handlebars.template()` 方法，生成的对象也可以以相同的方式使用。
 
 ## 在 NodeJS 中预编译模板
 


### PR DESCRIPTION
As pointed out in #124, we have to use `stdout` instead of `stderr` to get the CLI help-message.

Fixes #124

![image](https://github.com/handlebars-lang/docs/assets/1668766/b37d6ce0-a375-406b-a84f-907f3d1d1f5a)
