### PR TITLE
Added information for the Drupal Handlebars module

### DIFF
--- a/src/installation/integrations.md
+++ b/src/installation/integrations.md
@@ -69,7 +69,7 @@ TODO: Write text here
 
 https://www.npmjs.com/package/parcel-plugin-handlebars-precompile
 
-## Drupal CMS
+## Drupal
 
 Drupal is a CMS written in PHP + Symfony. There is a contrib module that allows you to integrate and use Handlebars
 in the front end to create progressively decoupled applications.

--- a/src/installation/integrations.md
+++ b/src/installation/integrations.md
@@ -68,3 +68,11 @@ The most recent one is: https://www.npmjs.com/package/@inventory/parcel-plugin-h
 TODO: Write text here
 
 https://www.npmjs.com/package/parcel-plugin-handlebars-precompile
+
+## Drupal CMS
+
+Drupal is a CMS written in PHP + Symfony. There is a contrib module that allows you to integrate and use Handlebars
+in the front end to create progressively decoupled applications.
+
+See [https://www.drupal.org/project/handlebars](https://www.drupal.org/project/handlebars) for instructions.
+


### PR DESCRIPTION
Added info about Drupal integration with a link to the Drupal Handlebars project.
The Drupal module links back to Handlebars.js homepage.