### PR TITLE
Creating interactive examples: Fix broken YAML links

### DIFF
--- a/src/contributing/interactive-examples.md
+++ b/src/contributing/interactive-examples.md
@@ -29,7 +29,7 @@ The output of the example is automatically computed using the latest release ver
 ## Example data
 
 If possible, examples should use variations of a common data set. Therefore, the file
-[src/\_examples/\_example-base-data.yaml](https://github.com/handlebars-lang/docs/blob/master/src/_examples/_example-base-data.yaml)
+[src/examples/\_example-base-data.yaml](https://github.com/handlebars-lang/docs/blob/master/src/examples/_example-base-data.yaml)
 contains data that can be reused and adapted to each example. If the data in that file is insufficient, please add new
 data, but please make sure it is somehow related.
 

--- a/src/zh/contributing/interactive-examples.md
+++ b/src/zh/contributing/interactive-examples.md
@@ -22,7 +22,7 @@ content   -`preparationScript`: 在编译和运行模板之前执行的脚本�
 ## 示例数据
 
 如果可能的话，示例应该使用通用数据集中提供的变量。因此，文件
-[src/\_examples/\_example-base-data.yaml](https://github.com/handlebars-lang/docs/blob/master/src/_examples/_example-base-data.yaml)
+[src/zh/examples/\_example-base-data.yaml](https://github.com/handlebars-lang/docs/blob/master/src/zh/examples/_example-base-data.yaml)
 包含了可重复使用并适用于每个示例的数据。如果该文件中的数据不足，请添加新的数据，但请确保它们之间存在关联。
 
 ## 嵌入示例


### PR DESCRIPTION
* Removes an underscore in front of the examples directory
* Adjusts the Chinese translation to link to its variant of the YAML file
* Korean translation is unaffected