### PR TITLE
Show the template used in guide/block helpers to reduce confusion.

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -126,9 +126,13 @@ mustache, `/`, of the same name. Let's consider a helper that will generate an H
 
 <Example examplePage="/examples/helper-block" show="preparationScript" />
 
-The example creates a helper named `list` to generate our HTML list. The helper receives the `people` as its first
-parameter, and an `options` hash as its second parameter. The options hash contains a property named `fn`, which you can
-invoke with a context just as you would invoke a normal Handlebars template.
+The example creates a helper named `list` to generate our HTML list.
+
+<Example examplePage="/examples/helper-block" show="template" />
+
+The helper receives the `people` as its first parameter, and an `options` hash as its second parameter. The options hash
+contains a property named `fn`, which you can invoke with a context just as you would invoke a normal Handlebars
+template.
 
 When executed, the template will render:
 


### PR DESCRIPTION
The current [guide/block helpers](https://handlebarsjs.com/guide/#block-helpers) section is a bit confusing as referenced in #186  and the PR #185.

@jaylinski is correct to point out that the descriptions reference to `people` is correct as seen in the example file used. However, the document is confusing to read with only the block helper preparation script and the generated output.

Showing the template from the example file makes the section flow better and easier to follow.