### PR TITLE
docs: note array index access with this.[n] in #each

### DIFF
--- a/src/guide/builtin-helpers.md
+++ b/src/guide/builtin-helpers.md
@@ -108,6 +108,18 @@ The first and last steps of iteration are noted via the [`@first`](../api-refere
 Nested `each` blocks may access the iteration variables via depth based paths. To access the parent index, for example,
 `{{@../index}}` can be used.
 
+When the current item is itself an array, use
+[segment-literal notation](expressions.md#literal-segments) to read a fixed index. Plain `this[0]` is not valid
+Handlebars syntax; write `this.[0]` instead:
+
+```handlebars
+<ul class="tuples">
+  {{#each tuple}}
+    <li>{{this.[0]}} {{this.[1]}}</li>
+  {{/each}}
+</ul>
+```
+
 :::
 
 ## #with


### PR DESCRIPTION
## Summary
- Document how to read fixed array indexes inside `#each` using segment-literal paths like `this.[0]`.
- Link to the existing Literal segments guide and call out that `this[0]` is not valid Handlebars syntax.

Fixes #188

## Test plan
- [ ] Preview the Built-in Helpers `#each` section and confirm the new note renders correctly
- [ ] Confirm the Literal segments link resolves